### PR TITLE
Fix cases with speak keyword in repeat sentence.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
 
-
-from adapt.intent import IntentBuilder
+import re
 from os.path import dirname, join
 
+from adapt.intent import IntentBuilder
 from mycroft import MycroftSkill, intent_handler
 
 
@@ -33,10 +33,10 @@ class SpeakSkill(MycroftSkill):
             TODO: The method is very english centric and will need
                   localization.
         """
-        # Get everything after say/speak/etc. and speak it back
-        words = message.data.get('utterance').split(message.data['Speak'])[1]
-        words = words.strip()
-        self.speak(words)
+        # Remove everything up to the speak keyword and repeat that
+        utterance = message.data.get('utterance')
+        repeat = re.sub('^.*?' + message.data['Speak'], '', utterance)
+        self.speak(repeat)
 
     def stop(self):
         pass


### PR DESCRIPTION
The case "say I say hello" did not render properly, ("I") since the
sentence was split at all "say" words. This new version properly removes
everyting up until and including the first occurance of the keyword and will render the example sentence correctly "I say hello"